### PR TITLE
重複していた処理を修正、他Code修正

### DIFF
--- a/TodoApp.xcodeproj/project.pbxproj
+++ b/TodoApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		162C585F250520E400F069A6 /* ItemListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162C585E250520E400F069A6 /* ItemListViewController.swift */; };
 		162C58642505259200F069A6 /* ItemListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162C58622505259200F069A6 /* ItemListTableViewCell.swift */; };
 		162C58652505259200F069A6 /* ItemListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 162C58632505259200F069A6 /* ItemListTableViewCell.xib */; };
+		16F1AF992518F752001E6D4D /* IdentifierType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F1AF982518F752001E6D4D /* IdentifierType.swift */; };
 		21150886F42BBA1F41CEC031 /* Pods_TodoApp_TodoAppUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E246E43E0527A7B3E3992B18 /* Pods_TodoApp_TodoAppUITests.framework */; };
 		26D053C4251118A0006A4675 /* items.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D053C3251118A0006A4675 /* items.swift */; };
 		61329914250874D200FC1819 /* ItemAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61329913250874D200FC1819 /* ItemAddViewController.swift */; };
@@ -59,6 +60,7 @@
 		162C585E250520E400F069A6 /* ItemListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListViewController.swift; sourceTree = "<group>"; };
 		162C58622505259200F069A6 /* ItemListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListTableViewCell.swift; sourceTree = "<group>"; };
 		162C58632505259200F069A6 /* ItemListTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ItemListTableViewCell.xib; sourceTree = "<group>"; };
+		16F1AF982518F752001E6D4D /* IdentifierType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierType.swift; sourceTree = "<group>"; };
 		1BEBF9910557AD691B2FC54E /* Pods-TodoAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TodoAppTests.debug.xcconfig"; path = "Target Support Files/Pods-TodoAppTests/Pods-TodoAppTests.debug.xcconfig"; sourceTree = "<group>"; };
 		26D053C3251118A0006A4675 /* items.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = items.swift; sourceTree = "<group>"; };
 		49581766F5C8789EBF727BB5 /* Pods_TodoApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TodoApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -126,6 +128,7 @@
 		162C582625051AC500F069A6 /* TodoApp */ = {
 			isa = PBXGroup;
 			children = (
+				16F1AF972518F6F1001E6D4D /* Identifier */,
 				26D053C225111856006A4675 /* Models */,
 				162C58612505222300F069A6 /* Controllers */,
 				162C58602505220500F069A6 /* Views */,
@@ -175,6 +178,14 @@
 			);
 			name = Controllers;
 			path = Views/Controllers;
+			sourceTree = "<group>";
+		};
+		16F1AF972518F6F1001E6D4D /* Identifier */ = {
+			isa = PBXGroup;
+			children = (
+				16F1AF982518F752001E6D4D /* IdentifierType.swift */,
+			);
+			path = Identifier;
 			sourceTree = "<group>";
 		};
 		26D053C225111856006A4675 /* Models */ = {
@@ -452,6 +463,7 @@
 				162C58642505259200F069A6 /* ItemListTableViewCell.swift in Sources */,
 				61329914250874D200FC1819 /* ItemAddViewController.swift in Sources */,
 				26D053C4251118A0006A4675 /* items.swift in Sources */,
+				16F1AF992518F752001E6D4D /* IdentifierType.swift in Sources */,
 				162C582825051AC500F069A6 /* AppDelegate.swift in Sources */,
 				162C582A25051AC500F069A6 /* SceneDelegate.swift in Sources */,
 				162C585F250520E400F069A6 /* ItemListViewController.swift in Sources */,

--- a/TodoApp/Identifier/IdentifierType.swift
+++ b/TodoApp/Identifier/IdentifierType.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-enum IdentifierType: String {
-    case segueId = "unwindByItemAdd"
-    case cellId = "Cell"
-    case nibId = "ItemListTableViewCell"
+enum IdentifierType {
+    static let segueId = "unwindByItemAdd"
+    static let cellId = "Cell"
+    static let nibId = "ItemListTableViewCell"
 }

--- a/TodoApp/Identifier/IdentifierType.swift
+++ b/TodoApp/Identifier/IdentifierType.swift
@@ -1,0 +1,15 @@
+//
+//  IdentifierType.swift
+//  TodoApp
+//
+//  Created by koji torishima on 2020/09/21.
+//  Copyright © 2020 LeanjoyFC. All rights reserved.
+//
+
+import Foundation
+
+enum IdentifierType: String {
+    case segueId = "unwindByItemAdd"
+    case cellId = "Cell"
+    case nibId = "ItemListTableViewCell"
+}

--- a/TodoApp/Models/items.swift
+++ b/TodoApp/Models/items.swift
@@ -9,7 +9,7 @@
 import RealmSwift
 
 // RealmSwiftでの保存用のclass作成（takuma）
-class CheckListItem2: Object {
+class CheckListItem: Object {
     @objc dynamic var itemName: String = ""
     @objc dynamic var isChecked: Bool = false
     

--- a/TodoApp/Views/Controllers/ItemAddViewController.swift
+++ b/TodoApp/Views/Controllers/ItemAddViewController.swift
@@ -22,7 +22,7 @@ final class ItemAddViewController: UIViewController {
     }
     
     @IBAction func addCheckItem(_ sender: Any) {
-        performSegue(withIdentifier: IdentifierType.segueId.rawValue, sender: nil)
+        performSegue(withIdentifier: IdentifierType.segueId, sender: nil)
     }
     
     @IBAction func cancelButton(_ sender: Any) {

--- a/TodoApp/Views/Controllers/ItemAddViewController.swift
+++ b/TodoApp/Views/Controllers/ItemAddViewController.swift
@@ -22,7 +22,7 @@ final class ItemAddViewController: UIViewController {
     }
     
     @IBAction func addCheckItem(_ sender: Any) {
-        performSegue(withIdentifier: "unwindByItemAdd", sender: nil)
+        performSegue(withIdentifier: IdentifierType.segueId.rawValue, sender: nil)
     }
     
     @IBAction func cancelButton(_ sender: Any) {

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -21,8 +21,8 @@ final class ItemListViewController: UIViewController {
     }
     
     private func setUpNib() {
-        let nib = UINib(nibName: IdentifierType.nibId.rawValue, bundle: nil)
-        itemListTableView.register(nib, forCellReuseIdentifier: IdentifierType.cellId.rawValue)
+        let nib = UINib(nibName: IdentifierType.nibId, bundle: nil)
+        itemListTableView.register(nib, forCellReuseIdentifier: IdentifierType.cellId)
         itemListTableView.delegate = self
         itemListTableView.dataSource = self
     }
@@ -33,7 +33,7 @@ final class ItemListViewController: UIViewController {
     }
     
     @IBAction func unwindToVC(_ unwindSegue: UIStoryboardSegue) {
-        guard unwindSegue.identifier == IdentifierType.segueId.rawValue else { return }
+        guard unwindSegue.identifier == IdentifierType.segueId else { return }
         let addItemVC = unwindSegue.source as! ItemAddViewController
         /// append
         itemListTableView.reloadData()
@@ -46,7 +46,7 @@ extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: IdentifierType.cellId.rawValue, for: indexPath) as! ItemListTableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: IdentifierType.cellId, for: indexPath) as! ItemListTableViewCell
         let item = itemList[indexPath.row]
         cell.checkImageView.image = nil
         cell.checkImageView.image = UIImage(named: "check")

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -9,85 +9,53 @@
 import UIKit
 import RealmSwift
 
-private struct CheckListItem {
-    var name : String
-    var check: Bool
-}
-
 final class ItemListViewController: UIViewController {
     
     @IBOutlet private weak var itemListTableView: UITableView!
-    
-    // チェックリスト
-    private var checkListItems: [CheckListItem] = []
-    
-    var itemList: Results<CheckListItem2>!
+    private var itemList: Results<CheckListItem>!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // チェックリストの初期化
-        checkListItems = [
-            CheckListItem(name: "リンゴ", check: false),
-            CheckListItem(name: "メロン", check: false),
-            CheckListItem(name: "バナナ", check: false),
-            CheckListItem(name: "パイナップル", check: false),
-            CheckListItem(name: "オレンジ", check: false)
-        ]
-        
         setUpNib()
         setRealm()
-        
     }
     
     private func setUpNib() {
-        let nib = UINib(nibName: "ItemListTableViewCell", bundle: nil)
-        itemListTableView.register(nib, forCellReuseIdentifier: "Cell")
+        let nib = UINib(nibName: IdentifierType.nibId.rawValue, bundle: nil)
+        itemListTableView.register(nib, forCellReuseIdentifier: IdentifierType.cellId.rawValue)
         itemListTableView.delegate = self
         itemListTableView.dataSource = self
     }
     
-    @IBAction func unwindToVC(_ unwindSegue: UIStoryboardSegue) {
-        // 注意!! まだstruct型に対応してないので、エラーが起きます！
-        // 追加ボタンを押下した場合
-        if unwindSegue.identifier == "unwindByItemAdd" {
-            let addItemVC = unwindSegue.source as! ItemAddViewController
-
-            let item = CheckListItem(name: addItemVC.testCheckItem, check: false)
-            checkListItems.append(item)
-
-            itemListTableView.reloadData()
-        }
-    }
-    
-    func setRealm() {
+    private func setRealm() {
         let realm = try! Realm()
-        itemList = realm.objects(CheckListItem2.self)
+        itemList = realm.objects(CheckListItem.self)
     }
     
-    
+    @IBAction func unwindToVC(_ unwindSegue: UIStoryboardSegue) {
+        guard unwindSegue.identifier == IdentifierType.segueId.rawValue else { return }
+        let addItemVC = unwindSegue.source as! ItemAddViewController
+        /// append
+        itemListTableView.reloadData()
+    }
 }
 
 extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        checkListItems.count
+        itemList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath) as! ItemListTableViewCell
-
-        let item = checkListItems[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: IdentifierType.cellId.rawValue, for: indexPath) as! ItemListTableViewCell
+        let item = itemList[indexPath.row]
         cell.checkImageView.image = nil
-          // testItemDataのcheckがtrueかを判断したい
-//        if   as? Bool == true {
-            cell.checkImageView.image = UIImage(named: "check")
-//        }
-        cell.itemTitle.text = item.name
+        cell.checkImageView.image = UIImage(named: "check")
+        cell.itemTitle.text = item.itemName
+        
         return cell
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // タップしたチェック項目のチェックマーク状態を反転
-        checkListItems[indexPath.row].check.toggle()
+        itemList[indexPath.row].isChecked.toggle()
     }
 }


### PR DESCRIPTION
## 今回行った作業の詳細を記入
- CheckListItemとCheckListItem2が重複していたため、Realmに一本化
- Identifierが直書きになっていたので、IdentifierTypeを定義し、直打ちをやめる
```swift
enum IdentifierType {}
```
- 今後Identifierが増えた場合ここに追加して、追加して定義しておけば、混在することを避けれるので作りました。
逆にわかりずらかったら戻します。

<!--具体的にどんな作業を行ったのか記入してください -->

## レビューして欲しい内容

<!-- 特にレビューして欲しいところがあれば記入してください -->

## 勉強になったところ

<!-- 今回の作業で勉強になったことを記入してください -->

## 躓いたところ

<!-- 今回の作業でわからなかったこと、躓いたところがあれば記入してください -->

## 参考になった資料などあれば共有してください

<!-- 今回の作業で調べて参考にした資料や記事等あればURLを貼ってみんなに共有しましょう!! -->

## スクリーンショット(Before, After)

<!-- もし画像などあれば貼ってみてください-->

Before | After
------------- | -------------
<img src="" width="320"> | <img src="" width="320">

## その他
<!-- 上記以外でも共有したいことがあればこちらに記入してください -->

