### PR TITLE
Edit画面を定義

### DIFF
--- a/TodoApp.xcodeproj/project.pbxproj
+++ b/TodoApp.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		162C58652505259200F069A6 /* ItemListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 162C58632505259200F069A6 /* ItemListTableViewCell.xib */; };
 		16F1AF992518F752001E6D4D /* IdentifierType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F1AF982518F752001E6D4D /* IdentifierType.swift */; };
 		21150886F42BBA1F41CEC031 /* Pods_TodoApp_TodoAppUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E246E43E0527A7B3E3992B18 /* Pods_TodoApp_TodoAppUITests.framework */; };
+		26C5252D25349BEA0029F83D /* ItemEdit.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 26C5252C25349BEA0029F83D /* ItemEdit.storyboard */; };
+		26C5253225349C770029F83D /* ItemEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C5253125349C770029F83D /* ItemEditViewController.swift */; };
 		26D053C4251118A0006A4675 /* items.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D053C3251118A0006A4675 /* items.swift */; };
 		61329914250874D200FC1819 /* ItemAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61329913250874D200FC1819 /* ItemAddViewController.swift */; };
 		613299162509B7C600FC1819 /* ItemAdd.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 613299152509B7C600FC1819 /* ItemAdd.storyboard */; };
@@ -62,6 +64,8 @@
 		162C58632505259200F069A6 /* ItemListTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ItemListTableViewCell.xib; sourceTree = "<group>"; };
 		16F1AF982518F752001E6D4D /* IdentifierType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierType.swift; sourceTree = "<group>"; };
 		1BEBF9910557AD691B2FC54E /* Pods-TodoAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TodoAppTests.debug.xcconfig"; path = "Target Support Files/Pods-TodoAppTests/Pods-TodoAppTests.debug.xcconfig"; sourceTree = "<group>"; };
+		26C5252C25349BEA0029F83D /* ItemEdit.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ItemEdit.storyboard; sourceTree = "<group>"; };
+		26C5253125349C770029F83D /* ItemEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemEditViewController.swift; sourceTree = "<group>"; };
 		26D053C3251118A0006A4675 /* items.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = items.swift; sourceTree = "<group>"; };
 		49581766F5C8789EBF727BB5 /* Pods_TodoApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TodoApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61329913250874D200FC1819 /* ItemAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemAddViewController.swift; sourceTree = "<group>"; };
@@ -163,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				613299152509B7C600FC1819 /* ItemAdd.storyboard */,
+				26C5252C25349BEA0029F83D /* ItemEdit.storyboard */,
 				162C585C250520BD00F069A6 /* ItemList.storyboard */,
 				162C58622505259200F069A6 /* ItemListTableViewCell.swift */,
 				162C58632505259200F069A6 /* ItemListTableViewCell.xib */,
@@ -175,6 +180,7 @@
 			children = (
 				162C585E250520E400F069A6 /* ItemListViewController.swift */,
 				61329913250874D200FC1819 /* ItemAddViewController.swift */,
+				26C5253125349C770029F83D /* ItemEditViewController.swift */,
 			);
 			name = Controllers;
 			path = Views/Controllers;
@@ -330,6 +336,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				162C58652505259200F069A6 /* ItemListTableViewCell.xib in Resources */,
+				26C5252D25349BEA0029F83D /* ItemEdit.storyboard in Resources */,
 				162C585D250520BD00F069A6 /* ItemList.storyboard in Resources */,
 				162C583425051AC500F069A6 /* LaunchScreen.storyboard in Resources */,
 				613299162509B7C600FC1819 /* ItemAdd.storyboard in Resources */,
@@ -482,6 +489,7 @@
 				162C58642505259200F069A6 /* ItemListTableViewCell.swift in Sources */,
 				61329914250874D200FC1819 /* ItemAddViewController.swift in Sources */,
 				26D053C4251118A0006A4675 /* items.swift in Sources */,
+				26C5253225349C770029F83D /* ItemEditViewController.swift in Sources */,
 				16F1AF992518F752001E6D4D /* IdentifierType.swift in Sources */,
 				162C582825051AC500F069A6 /* AppDelegate.swift in Sources */,
 				162C582A25051AC500F069A6 /* SceneDelegate.swift in Sources */,

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -15,4 +15,8 @@ final class ItemEditViewController: UIViewController {
 
     }
     
+    @IBAction func cancelButton(_ sender: Any) {
+        dismiss(animated: true, completion: nil)
+    }
+
 }

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -13,18 +13,6 @@ final class ItemEditViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -1,0 +1,30 @@
+//
+//  ItemEditViewController.swift
+//  TodoApp
+//
+//  Created by 小川卓馬 on 2020/10/12.
+//  Copyright © 2020 LeanjoyFC. All rights reserved.
+//
+
+import UIKit
+
+final class ItemEditViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -15,7 +15,7 @@ final class ItemEditViewController: UIViewController {
 
     }
     
-    @IBAction func cancelButton(_ sender: Any) {
+    @IBAction func cancelButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
     }
 

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -76,4 +76,8 @@ extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
         }
         itemListTableView.reloadRows(at: [indexPath], with: .automatic)
     }
+    
+    func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
+        performSegue(withIdentifier: "itemEdit", sender: nil)
+    }
 }

--- a/TodoApp/Views/ItemEdit.storyboard
+++ b/TodoApp/Views/ItemEdit.storyboard
@@ -42,7 +42,7 @@
                     <navigationItem key="navigationItem" title="項目編集" id="eF4-9K-kFr">
                         <barButtonItem key="leftBarButtonItem" title="Cancel" id="i5P-Pz-Ibp">
                             <connections>
-                                <action selector="cancelButton:" destination="kcR-wB-Iad" id="ZiW-Kq-eAJ"/>
+                                <action selector="cancelButton:" destination="kcR-wB-Iad" id="CII-TP-hzW"/>
                             </connections>
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Save" id="Wma-qt-ArF"/>

--- a/TodoApp/Views/ItemEdit.storyboard
+++ b/TodoApp/Views/ItemEdit.storyboard
@@ -40,7 +40,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="項目編集" id="eF4-9K-kFr">
-                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="i5P-Pz-Ibp"/>
+                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="i5P-Pz-Ibp">
+                            <connections>
+                                <action selector="cancelButton:" destination="kcR-wB-Iad" id="ZiW-Kq-eAJ"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Save" id="Wma-qt-ArF"/>
                     </navigationItem>
                 </viewController>

--- a/TodoApp/Views/ItemEdit.storyboard
+++ b/TodoApp/Views/ItemEdit.storyboard
@@ -8,21 +8,45 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Item Edit View Controller-->
+        <!--項目編集-->
         <scene sceneID="M9T-5j-FdP">
             <objects>
                 <viewController id="kcR-wB-Iad" customClass="ItemEditViewController" customModule="TodoApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="v0y-XF-mWF">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="名前" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xms-n0-Wta">
+                                <rect key="frame" x="40" y="155" width="35" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pL7-fM-fga">
+                                <rect key="frame" x="101" y="148" width="293" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="OVp-Vx-BWL"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Xms-n0-Wta" firstAttribute="leading" secondItem="OVp-Vx-BWL" secondAttribute="leading" constant="40" id="GWU-pj-JgS"/>
+                            <constraint firstItem="pL7-fM-fga" firstAttribute="leading" secondItem="Xms-n0-Wta" secondAttribute="trailing" constant="26" id="YTT-0P-wIG"/>
+                            <constraint firstItem="Xms-n0-Wta" firstAttribute="top" secondItem="OVp-Vx-BWL" secondAttribute="top" constant="67" id="Yhg-fV-GYl"/>
+                            <constraint firstItem="pL7-fM-fga" firstAttribute="top" secondItem="OVp-Vx-BWL" secondAttribute="top" constant="60" id="b4I-Lx-WCK"/>
+                            <constraint firstItem="pL7-fM-fga" firstAttribute="leading" secondItem="Xms-n0-Wta" secondAttribute="trailing" constant="26" id="gCL-zv-tZO"/>
+                            <constraint firstItem="OVp-Vx-BWL" firstAttribute="trailing" secondItem="pL7-fM-fga" secondAttribute="trailing" constant="20" id="mxB-52-WgN"/>
+                        </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="eF4-9K-kFr"/>
+                    <navigationItem key="navigationItem" title="項目編集" id="eF4-9K-kFr">
+                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="i5P-Pz-Ibp"/>
+                        <barButtonItem key="rightBarButtonItem" title="Save" id="Wma-qt-ArF"/>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x6n-7p-9wI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1137.68115942029" y="-15.401785714285714"/>
+            <point key="canvasLocation" x="945" y="-15"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="6NF-LB-0n0">

--- a/TodoApp/Views/ItemEdit.storyboard
+++ b/TodoApp/Views/ItemEdit.storyboard
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="v5z-BQ-mIB">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Item Edit View Controller-->
+        <scene sceneID="M9T-5j-FdP">
+            <objects>
+                <viewController id="kcR-wB-Iad" customClass="ItemEditViewController" customModule="TodoApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="v0y-XF-mWF">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="OVp-Vx-BWL"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="eF4-9K-kFr"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x6n-7p-9wI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1137.68115942029" y="-15.401785714285714"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="6NF-LB-0n0">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="v5z-BQ-mIB" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="gmy-4O-MyD">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="kcR-wB-Iad" kind="relationship" relationship="rootViewController" id="k4w-Uo-Jc2"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5iM-jR-10e" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="227.536231884058" y="-15.401785714285714"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/TodoApp/Views/ItemList.storyboard
+++ b/TodoApp/Views/ItemList.storyboard
@@ -40,7 +40,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="itemListTableView" destination="29h-Ba-gqV" id="MVP-wz-oSh"/>
-                        <segue destination="h5S-1J-O5e" kind="presentation" id="9dN-H6-Yza"/>
+                        <segue destination="h5S-1J-O5e" kind="presentation" identifier="itemEdit" id="9dN-H6-Yza"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PeI-hD-io9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/TodoApp/Views/ItemList.storyboard
+++ b/TodoApp/Views/ItemList.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4qC-kh-rG9">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4qC-kh-rG9">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,17 +18,17 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="29h-Ba-gqV">
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Ku-71-Hdi"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="29h-Ba-gqV" secondAttribute="bottom" id="Itu-rm-6n0"/>
                             <constraint firstItem="29h-Ba-gqV" firstAttribute="top" secondItem="6Ku-71-Hdi" secondAttribute="top" id="VLH-Wf-CGZ"/>
                             <constraint firstItem="29h-Ba-gqV" firstAttribute="leading" secondItem="6Ku-71-Hdi" secondAttribute="leading" id="pVK-aT-8nd"/>
                             <constraint firstItem="29h-Ba-gqV" firstAttribute="trailing" secondItem="6Ku-71-Hdi" secondAttribute="trailing" id="ytX-Up-0o1"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Ku-71-Hdi"/>
                     </view>
                     <navigationItem key="navigationItem" title="チェックリスト" id="ArX-NR-RhK">
                         <barButtonItem key="backBarButtonItem" title="Cancel" id="Gpi-gS-fMF"/>
@@ -39,6 +40,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="itemListTableView" destination="29h-Ba-gqV" id="MVP-wz-oSh"/>
+                        <segue destination="h5S-1J-O5e" kind="presentation" id="9dN-H6-Yza"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PeI-hD-io9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -52,6 +54,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ym8-EO-JIZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2924" y="-986"/>
+        </scene>
+        <!--ItemEdit-->
+        <scene sceneID="vVi-BZ-WnF">
+            <objects>
+                <viewControllerPlaceholder storyboardName="ItemEdit" id="h5S-1J-O5e" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4br-8N-tp8" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2924" y="-838"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="eG6-JE-Hes">
@@ -74,5 +84,8 @@
     </scenes>
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/TodoApp/Views/ItemListTableViewCell.swift
+++ b/TodoApp/Views/ItemListTableViewCell.swift
@@ -15,7 +15,7 @@ class ItemListTableViewCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        
+
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/TodoApp/Views/ItemListTableViewCell.xib
+++ b/TodoApp/Views/ItemListTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,19 +21,25 @@
                         <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default"/>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="asc-pG-h6i">
-                        <rect key="frame" x="30" y="10" width="274" height="24"/>
+                        <rect key="frame" x="30" y="10" width="250" height="24"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bHJ-we-qZD">
+                        <rect key="frame" x="285" y="11" width="20" height="22"/>
+                        <state key="normal" image="info.circle" catalog="system"/>
+                    </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="trailing" secondItem="asc-pG-h6i" secondAttribute="trailing" constant="40" id="1LT-yu-uyN"/>
                     <constraint firstAttribute="trailing" secondItem="pp0-Wh-Fg0" secondAttribute="trailing" constant="295" id="5TI-qF-SXT"/>
-                    <constraint firstItem="asc-pG-h6i" firstAttribute="leading" secondItem="pp0-Wh-Fg0" secondAttribute="trailing" constant="5" id="630-n5-ahz"/>
-                    <constraint firstAttribute="bottom" secondItem="asc-pG-h6i" secondAttribute="bottom" constant="10" id="8ff-0R-QC3"/>
-                    <constraint firstAttribute="trailing" secondItem="asc-pG-h6i" secondAttribute="trailing" constant="16" id="FBa-lE-Faj"/>
-                    <constraint firstItem="asc-pG-h6i" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="agy-KW-Pib"/>
+                    <constraint firstItem="asc-pG-h6i" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="DFU-Wq-AOG"/>
+                    <constraint firstItem="bHJ-we-qZD" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="JWT-un-x0v"/>
+                    <constraint firstAttribute="bottom" secondItem="asc-pG-h6i" secondAttribute="bottom" constant="10" id="Mfv-dm-KpM"/>
+                    <constraint firstAttribute="trailing" secondItem="bHJ-we-qZD" secondAttribute="trailing" constant="15" id="cGr-ec-oXd"/>
                     <constraint firstAttribute="bottom" secondItem="pp0-Wh-Fg0" secondAttribute="bottom" constant="9" id="dOA-QC-6O1"/>
+                    <constraint firstItem="asc-pG-h6i" firstAttribute="leading" secondItem="pp0-Wh-Fg0" secondAttribute="trailing" constant="5" id="fMz-NK-Nw3"/>
                     <constraint firstItem="pp0-Wh-Fg0" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="oNr-sG-g7O"/>
                     <constraint firstItem="pp0-Wh-Fg0" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="ycx-re-1sB"/>
                 </constraints>
@@ -48,5 +54,6 @@
     </objects>
     <resources>
         <image name="check" width="44" height="44"/>
+        <image name="info.circle" catalog="system" width="128" height="121"/>
     </resources>
 </document>

--- a/TodoApp/Views/ItemListTableViewCell.xib
+++ b/TodoApp/Views/ItemListTableViewCell.xib
@@ -9,35 +9,29 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" id="KGk-i7-Jjw" customClass="ItemListTableViewCell" customModule="TodoApp" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="detailButton" indentationWidth="10" reuseIdentifier="Cell" id="KGk-i7-Jjw" customClass="ItemListTableViewCell" customModule="TodoApp" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="280" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="check" translatesAutoresizingMaskIntoConstraints="NO" id="pp0-Wh-Fg0">
-                        <rect key="frame" x="0.0" y="10" width="25" height="25"/>
+                        <rect key="frame" x="0.0" y="10" width="44" height="25"/>
                         <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default"/>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="asc-pG-h6i">
-                        <rect key="frame" x="30" y="10" width="250" height="24"/>
+                        <rect key="frame" x="49" y="10" width="41.5" height="24"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bHJ-we-qZD">
-                        <rect key="frame" x="285" y="11" width="20" height="22"/>
-                        <state key="normal" image="info.circle" catalog="system"/>
-                    </button>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="asc-pG-h6i" secondAttribute="trailing" constant="40" id="1LT-yu-uyN"/>
                     <constraint firstAttribute="trailing" secondItem="pp0-Wh-Fg0" secondAttribute="trailing" constant="295" id="5TI-qF-SXT"/>
                     <constraint firstItem="asc-pG-h6i" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="DFU-Wq-AOG"/>
-                    <constraint firstItem="bHJ-we-qZD" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="JWT-un-x0v"/>
                     <constraint firstAttribute="bottom" secondItem="asc-pG-h6i" secondAttribute="bottom" constant="10" id="Mfv-dm-KpM"/>
-                    <constraint firstAttribute="trailing" secondItem="bHJ-we-qZD" secondAttribute="trailing" constant="15" id="cGr-ec-oXd"/>
                     <constraint firstAttribute="bottom" secondItem="pp0-Wh-Fg0" secondAttribute="bottom" constant="9" id="dOA-QC-6O1"/>
                     <constraint firstItem="asc-pG-h6i" firstAttribute="leading" secondItem="pp0-Wh-Fg0" secondAttribute="trailing" constant="5" id="fMz-NK-Nw3"/>
                     <constraint firstItem="pp0-Wh-Fg0" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="oNr-sG-g7O"/>
@@ -54,6 +48,5 @@
     </objects>
     <resources>
         <image name="check" width="44" height="44"/>
-        <image name="info.circle" catalog="system" width="128" height="121"/>
     </resources>
 </document>


### PR DESCRIPTION
## 今回行った作業の詳細を記入
- ItemEditViewController作成
- ItemListViewControllerとStoryBoardReferenceで接続
- ItemListVCのセル、ItemEditVCにそれぞれ必要なUIを設置
infoボタンはセルのアクセサリーをDetailにして実装
- ItemListVC <-> ItemEditVC間の遷移を実装

<!--具体的にどんな作業を行ったのか記入してください -->

## レビューして欲しい内容

<!-- 特にレビューして欲しいところがあれば記入してください -->

## 勉強になったところ

<!-- 今回の作業で勉強になったことを記入してください -->

## 躓いたところ
下記参考資料を見るまでは、infoマークをUIButtonで作成していて、遷移の実装が出来ていなかったです。
（2時間くらい進捗なしが続いてました。。）
もしセル上にボタンを設置した場合で遷移できる方法を知っている方がいれば、教えていただきたいです。
セルにボタンを配置し、ボタンのアクションでperformSegueをすることはできなかったです。
![スクリーンショット 2020-10-15 22 57 28](https://user-images.githubusercontent.com/52493391/96139788-277dae80-0f3a-11eb-96f9-1db4de21cb8e.png)
<!-- 今回の作業でわからなかったこと、躓いたところがあれば記入してください -->

## 参考になった資料などあれば共有してください
- あきおさんのYouTube
[Xcodeアプリ開発入門] Part57 セルの右端にiボタンを表示する（accessoryButtonTappedForRowWithIndexPath）
https://www.youtube.com/watch?v=kYGyNGaiRn8&list=PLQ5rERkGSxF9_soz3Ns-SpURWsy0WmbJQ&index=57

<!-- 今回の作業で調べて参考にした資料や記事等あればURLを貼ってみんなに共有しましょう!! -->

## スクリーンショット(Before, After)

<!-- もし画像などあれば貼ってみてください-->

Before | After
------------- | -------------
<img src="" width="320"> | <img src="" width="320">

## その他
<!-- 上記以外でも共有したいことがあればこちらに記入してください -->

