### PR TITLE
ItemListVCからItemEditVCへのデータの受け渡しとItemEditVCからItemListVCへの遷移を実装

### DIFF
--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -7,16 +7,40 @@
 //
 
 import UIKit
+import RealmSwift
 
 final class ItemEditViewController: UIViewController {
-
+    
+    @IBOutlet private weak var editTextField: UITextField!
+    
+    var editItemName: String = ""
+    var editedItemName: String = ""
+    var itemList:Results<CheckListItem>?
+    private let realm = try! Realm()
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+ 
+        editTextField.text = editItemName //編集前のタスク名を表示
+        
+    }
+    @IBAction func saveButton(_ sender: UIBarButtonItem) {
+        // 1文字も入力されてなければ、アラートで警告し、処理を中断
+        if editTextField.text!.isEmpty {
+            let alert = UIAlertController(title: "エラー", message: "1文字以上を入力してください", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+            present(alert, animated: true, completion:  nil)
+            return
+        }
+        //unwindSegueでItemListViewControllerに戻る
+        editedItemName = editTextField.text!
+        print(editedItemName)
+        performSegue(withIdentifier: IdentifierType.editSegueId, sender: nil)
     }
     
     @IBAction func cancelButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
     }
-
+    
 }

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -12,6 +12,7 @@ import RealmSwift
 final class ItemEditViewController: UIViewController {
     
     @IBOutlet private weak var editTextField: UITextField!
+    @IBOutlet private weak var saveButton: UIBarButtonItem!
     
     var editItemName: String = ""
     var editedItemName: String = ""
@@ -21,18 +22,20 @@ final class ItemEditViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
- 
         editTextField.text = editItemName //編集前のタスク名を表示
-        
     }
-    @IBAction func saveButton(_ sender: UIBarButtonItem) {
-        // 1文字も入力されてなければ、アラートで警告し、処理を中断
-        if editTextField.text!.isEmpty {
-            let alert = UIAlertController(title: "エラー", message: "1文字以上を入力してください", preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
-            present(alert, animated: true, completion:  nil)
-            return
+    
+    // TextFieldに文字が入力されているか確認し、SaveButtonの無効化と有効化を切り替える
+    @IBAction func checkTextFieldIsEmpty(_ sender: Any) {
+        if editTextField.text == "" {
+            saveButton.isEnabled = false
+        } else {
+            saveButton.isEnabled = true
         }
+    }
+    
+    
+    @IBAction func saveButton(_ sender: UIBarButtonItem) {
         //unwindSegueでItemListViewControllerに戻る
         editedItemName = editTextField.text!
         print(editedItemName)

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -15,16 +15,14 @@ final class ItemListViewController: UIViewController {
  
     @IBOutlet private weak var itemListTableView: UITableView!
     private var itemList: Results<CheckListItem>!
+    private var editCellIndexPath: Int?  //編集するcellのindexPathを保存する変数
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpNib()
         setRealm()
         
-//        print(Realm.Configuration.defaultConfiguration.fileURL!)
-//        let key = Realm.Configuration.defaultConfiguration.encryptionKey!
-//        let hexaDecimal = key.map { String(format: "%.2hhx", $0) }.joined()
-//        print(hexaDecimal)
+        print(Realm.Configuration.defaultConfiguration.fileURL!)
     }
     
     private func setUpNib() {
@@ -48,13 +46,13 @@ final class ItemListViewController: UIViewController {
     }
     
     //　itemNameを更新する関数
-//    private func editRealm(itemName: String, isChecked: Bool) {
-//        let editItem = realm.objects(CheckListItem.self)
-//        try! realm.write {
-//            editItem.itemName = itemName
-//            editItem.isChecked = isChecked
-//        }
-//    }
+    func editRealm(itemName: String, isChecked: Bool) {
+        let editItem = realm.objects(CheckListItem.self)
+        try! realm.write {
+            editItem[editCellIndexPath!].itemName = itemName
+            editItem[editCellIndexPath!].isChecked = isChecked
+        }
+    }
     
     @IBAction func unwindToVC(_ unwindSegue: UIStoryboardSegue) {
         guard unwindSegue.identifier == IdentifierType.segueId else { return }
@@ -69,9 +67,8 @@ final class ItemListViewController: UIViewController {
         guard unwindSegue.identifier == IdentifierType.editSegueId else { return }
         let itemEditVC = unwindSegue.source as! ItemEditViewController
         print(itemEditVC.editedItemName)
-//        editRealm(itemName: itemEditVC.editedItemName, isChecked: false)
+        editRealm(itemName: itemEditVC.editedItemName, isChecked: false)
         itemListTableView.reloadData()
-        
     }
     
 }
@@ -103,6 +100,7 @@ extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
     
     //編集前のタスク名をitemEditVCに渡す
     func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
+        editCellIndexPath = indexPath.row //編集するCellのindexPathを取得
         performSegue(withIdentifier: "itemEdit", sender: itemList[indexPath.row].itemName)
     }
     

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -20,6 +20,11 @@ final class ItemListViewController: UIViewController {
         super.viewDidLoad()
         setUpNib()
         setRealm()
+        
+//        print(Realm.Configuration.defaultConfiguration.fileURL!)
+//        let key = Realm.Configuration.defaultConfiguration.encryptionKey!
+//        let hexaDecimal = key.map { String(format: "%.2hhx", $0) }.joined()
+//        print(hexaDecimal)
     }
     
     private func setUpNib() {
@@ -40,8 +45,16 @@ final class ItemListViewController: UIViewController {
         try! realm.write() {
             realm.add(addItem)
         }
-        
     }
+    
+    //　itemNameを更新する関数
+//    private func editRealm(itemName: String, isChecked: Bool) {
+//        let editItem = realm.objects(CheckListItem.self)
+//        try! realm.write {
+//            editItem.itemName = itemName
+//            editItem.isChecked = isChecked
+//        }
+//    }
     
     @IBAction func unwindToVC(_ unwindSegue: UIStoryboardSegue) {
         guard unwindSegue.identifier == IdentifierType.segueId else { return }
@@ -50,6 +63,17 @@ final class ItemListViewController: UIViewController {
         addRealm(itemName: addItemVC.betaCheckItemName, isChecked: false)
         itemListTableView.reloadData()
     }
+    
+    // Segueで渡されたeditedItemName変数を基にeditRealm関数でrealmデータを更新し、TableViewをリロード
+    @IBAction func unwindToVCFromEditVC(_ unwindSegue: UIStoryboardSegue) {
+        guard unwindSegue.identifier == IdentifierType.editSegueId else { return }
+        let itemEditVC = unwindSegue.source as! ItemEditViewController
+        print(itemEditVC.editedItemName)
+//        editRealm(itemName: itemEditVC.editedItemName, isChecked: false)
+        itemListTableView.reloadData()
+        
+    }
+    
 }
 
 extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
@@ -77,7 +101,16 @@ extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
         itemListTableView.reloadRows(at: [indexPath], with: .automatic)
     }
     
+    //編集前のタスク名をitemEditVCに渡す
     func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
-        performSegue(withIdentifier: "itemEdit", sender: nil)
+        performSegue(withIdentifier: "itemEdit", sender: itemList[indexPath.row].itemName)
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "itemEdit" {
+            let nav =  segue.destination as! UINavigationController
+            let itemEditVC = nav.viewControllers[nav.viewControllers.count-1] as! ItemEditViewController
+            itemEditVC.editItemName = sender as! String
+        }
     }
 }


### PR DESCRIPTION
## 今回行った作業の詳細を記入

<!--具体的にどんな作業を行ったのか記入してください -->
ItemListVC内の、accessoryButtonTappedForRowWithメソッド内のperformSegueで
senderにitemList[indexPath.row].itemNameを設定し、prepare()でItemEditVCのeditItemName変数にsenderを代入。ItemEditVCのviewDidLoadで、editItemName変数をeditTextFieldに代入し、編集前のitemNameをテキストフィールドに表示。

編集画面で編集が完了し、SaveButtonが押されたら、テキストフィールドに一文字以上入力されているか確認し、されていなければアラートを表示。入力が完了されれば、ItemListVCに設定したunwindSegueでItemListVCに遷移 



## レビューして欲しい内容

<!-- 特にレビューして欲しいところがあれば記入してください -->
関数や変数の命名についてですが、既存の関数名、変数名と差別化を図りつつ、かつ機能の類似した関数については関連性がわかるような命名をしました。しかし、これがかえって実装をしていないみなさんにとっては混乱を招くものであるのかがわからないため、レビューいただきたいです。
（例）
ItemListViewController内の59行目、68行目
・unwindToVC()
・unwindToVCFromEditVC()

ItemEditViewController内の16行目、17行目
・editItemName
・editedItemName



## 勉強になったところ

<!-- 今回の作業で勉強になったことを記入してください -->



## 躓いたところ

<!-- 今回の作業でわからなかったこと、躓いたところがあれば記入してください -->
今回の作業ではないのですが、itemNameを更新する関数をItemListVCの51行目から57行目に書いたのですが、54行目と55行目の  .itemName　と　.isChecked　が editItemのメンバにありません　と表示されてしまいます。Realmの勉強を今必死にしているところですが、もしこうしたらいいかもということがあれば教えていただけると嬉しいです！

## 参考になった資料などあれば共有してください

<!-- 今回の作業で調べて参考にした資料や記事等あればURLを貼ってみんなに共有しましょう!! -->

## スクリーンショット(Before, After)

<!-- もし画像などあれば貼ってみてください-->

Before | After
------------- | -------------
<img src="" width="320"> | <img src="" width="320">

## その他
<!-- 上記以外でも共有したいことがあればこちらに記入してください -->

