### PR TITLE
Edit画面とList画面を連携

### DIFF
--- a/TodoApp/Identifier/IdentifierType.swift
+++ b/TodoApp/Identifier/IdentifierType.swift
@@ -12,5 +12,4 @@ enum IdentifierType {
     static let segueId = "unwindByItemAdd"
     static let cellId = "Cell"
     static let nibId = "ItemListTableViewCell"
-    static let editSegueId = "unwindByItemEdit"
 }

--- a/TodoApp/Identifier/IdentifierType.swift
+++ b/TodoApp/Identifier/IdentifierType.swift
@@ -12,4 +12,5 @@ enum IdentifierType {
     static let segueId = "unwindByItemAdd"
     static let cellId = "Cell"
     static let nibId = "ItemListTableViewCell"
+    static let editSegueId = "unwindByItemEdit"
 }

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -15,8 +15,7 @@ final class ItemEditViewController: UIViewController {
     @IBOutlet private weak var saveButton: UIBarButtonItem!
     
     var editItemName: String = ""
-    var editedItemName: String = ""
-    var itemList:Results<CheckListItem>?
+    private(set) var editedItemName: String = ""
     private let realm = try! Realm()
     
     

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -41,7 +41,6 @@ final class ItemEditViewController: UIViewController {
     @IBAction func saveButton(_ sender: UIBarButtonItem) {
         //unwindSegueでItemListViewControllerに戻る
         editedItemName = editTextField.text!
-        print(editedItemName)
         performSegue(withIdentifier: SegueIdentifier.edit, sender: nil)
     }
     

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -14,7 +14,7 @@ final class ItemEditViewController: UIViewController {
     @IBOutlet private weak var editTextField: UITextField!
     @IBOutlet private weak var saveButton: UIBarButtonItem!
     
-    var editItemName: String = ""
+    var selectedItemName: String = ""
     private(set) var editedItemName: String = ""
     private let realm = try! Realm()
     
@@ -25,7 +25,7 @@ final class ItemEditViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        editTextField.text = editItemName //編集前のタスク名を表示
+        editTextField.text = selectedItemName //編集前のタスク名を表示
     }
     
     // TextFieldに文字が入力されているか確認し、SaveButtonの無効化と有効化を切り替える

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -7,16 +7,40 @@
 //
 
 import UIKit
+import RealmSwift
 
 final class ItemEditViewController: UIViewController {
-
+    
+    @IBOutlet private weak var editTextField: UITextField!
+    
+    var editItemName: String = ""
+    var editedItemName: String = ""
+    var itemList:Results<CheckListItem>?
+    private let realm = try! Realm()
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+ 
+        editTextField.text = editItemName //編集前のタスク名を表示
+        
+    }
+    @IBAction func saveButton(_ sender: UIBarButtonItem) {
+        // 1文字も入力されてなければ、アラートで警告し、処理を中断
+        if editTextField.text!.isEmpty {
+            let alert = UIAlertController(title: "エラー", message: "1文字以上を入力してください", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+            present(alert, animated: true, completion:  nil)
+            return
+        }
+        //unwindSegueでItemListViewControllerに戻る
+        editedItemName = editTextField.text!
+        print(editedItemName)
+        performSegue(withIdentifier: IdentifierType.editSegueId, sender: nil)
     }
     
     @IBAction func cancelButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
     }
-
+    
 }

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -12,6 +12,7 @@ import RealmSwift
 final class ItemEditViewController: UIViewController {
     
     @IBOutlet private weak var editTextField: UITextField!
+    @IBOutlet private weak var saveButton: UIBarButtonItem!
     
     var editItemName: String = ""
     var editedItemName: String = ""
@@ -21,18 +22,20 @@ final class ItemEditViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
- 
         editTextField.text = editItemName //編集前のタスク名を表示
-        
     }
-    @IBAction func saveButton(_ sender: UIBarButtonItem) {
-        // 1文字も入力されてなければ、アラートで警告し、処理を中断
-        if editTextField.text!.isEmpty {
-            let alert = UIAlertController(title: "エラー", message: "1文字以上を入力してください", preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
-            present(alert, animated: true, completion:  nil)
-            return
+    
+    // TextFieldに文字が入力されているか確認し、SaveButtonの無効化と有効化を切り替える
+    @IBAction func checkTextFieldIsEmpty(_ sender: Any) {
+        if editTextField.text == "" {
+            saveButton.isEnabled = false
+        } else {
+            saveButton.isEnabled = true
         }
+    }
+    
+    
+    @IBAction func saveButton(_ sender: UIBarButtonItem) {
         //unwindSegueでItemListViewControllerに戻る
         editedItemName = editTextField.text!
         print(editedItemName)

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -30,7 +30,7 @@ final class ItemEditViewController: UIViewController {
     
     // TextFieldに文字が入力されているか確認し、SaveButtonの無効化と有効化を切り替える
     @IBAction func checkTextFieldIsEmpty(_ sender: Any) {
-        if editTextField.text == "" {
+        if editTextField.text!.isEmpty {
             saveButton.isEnabled = false
         } else {
             saveButton.isEnabled = true

--- a/TodoApp/Views/Controllers/ItemEditViewController.swift
+++ b/TodoApp/Views/Controllers/ItemEditViewController.swift
@@ -18,6 +18,10 @@ final class ItemEditViewController: UIViewController {
     private(set) var editedItemName: String = ""
     private let realm = try! Realm()
     
+    private enum SegueIdentifier {
+        static let edit = "unwindByItemEdit"
+    }
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,7 +42,7 @@ final class ItemEditViewController: UIViewController {
         //unwindSegueでItemListViewControllerに戻る
         editedItemName = editTextField.text!
         print(editedItemName)
-        performSegue(withIdentifier: IdentifierType.editSegueId, sender: nil)
+        performSegue(withIdentifier: SegueIdentifier.edit, sender: nil)
     }
     
     @IBAction func cancelButton(_ sender: UIBarButtonItem) {

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -15,16 +15,14 @@ final class ItemListViewController: UIViewController {
  
     @IBOutlet private weak var itemListTableView: UITableView!
     private var itemList: Results<CheckListItem>!
+    private var editCellIndexPath: Int?  //編集するcellのindexPathを保存する変数
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpNib()
         setRealm()
         
-//        print(Realm.Configuration.defaultConfiguration.fileURL!)
-//        let key = Realm.Configuration.defaultConfiguration.encryptionKey!
-//        let hexaDecimal = key.map { String(format: "%.2hhx", $0) }.joined()
-//        print(hexaDecimal)
+        print(Realm.Configuration.defaultConfiguration.fileURL!)
     }
     
     private func setUpNib() {
@@ -48,13 +46,13 @@ final class ItemListViewController: UIViewController {
     }
     
     //　itemNameを更新する関数
-//    private func editRealm(itemName: String, isChecked: Bool) {
-//        let editItem = realm.objects(CheckListItem.self)
-//        try! realm.write {
-//            editItem.itemName = itemName
-//            editItem.isChecked = isChecked
-//        }
-//    }
+    func editRealm(itemName: String, isChecked: Bool) {
+        let editItem = realm.objects(CheckListItem.self)
+        try! realm.write {
+            editItem[editCellIndexPath!].itemName = itemName
+            editItem[editCellIndexPath!].isChecked = isChecked
+        }
+    }
     
     @IBAction func unwindToVC(_ unwindSegue: UIStoryboardSegue) {
         guard unwindSegue.identifier == IdentifierType.segueId else { return }
@@ -69,9 +67,8 @@ final class ItemListViewController: UIViewController {
         guard unwindSegue.identifier == IdentifierType.editSegueId else { return }
         let itemEditVC = unwindSegue.source as! ItemEditViewController
         print(itemEditVC.editedItemName)
-//        editRealm(itemName: itemEditVC.editedItemName, isChecked: false)
+        editRealm(itemName: itemEditVC.editedItemName, isChecked: false)
         itemListTableView.reloadData()
-        
     }
     
 }
@@ -103,6 +100,7 @@ extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
     
     //編集前のタスク名をitemEditVCに渡す
     func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
+        editCellIndexPath = indexPath.row //編集するCellのindexPathを取得
         performSegue(withIdentifier: "itemEdit", sender: itemList[indexPath.row].itemName)
     }
     

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -106,7 +106,7 @@ extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "itemEdit" {
             let nav =  segue.destination as! UINavigationController
-            let itemEditVC = nav.viewControllers[nav.viewControllers.count-1] as! ItemEditViewController
+            let itemEditVC = nav.topViewController as! ItemEditViewController
             itemEditVC.selectedItemName = sender as! String
         }
     }

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -50,10 +50,9 @@ final class ItemListViewController: UIViewController {
     
     //　itemNameを更新する関数
     private func editRealm(itemName: String, isChecked: Bool) {
-        let editItem = realm.objects(CheckListItem.self)
         try! realm.write {
-            editItem[selectedIndexPathRow!].itemName = itemName
-            editItem[selectedIndexPathRow!].isChecked = isChecked
+            itemList[selectedIndexPathRow!].itemName = itemName
+            itemList[selectedIndexPathRow!].isChecked = isChecked
         }
     }
     

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -15,7 +15,7 @@ final class ItemListViewController: UIViewController {
  
     @IBOutlet private weak var itemListTableView: UITableView!
     private var itemList: Results<CheckListItem>!
-    private var editCellIndexPath: Int?  //編集するcellのindexPathを保存する変数
+    private var selectedIndexPathRow: Int?  //編集するcellのindexPathを保存する変数
     private enum SegueIdentifier {
         static let edit = "unwindByItemEdit"
     }
@@ -52,8 +52,8 @@ final class ItemListViewController: UIViewController {
     private func editRealm(itemName: String, isChecked: Bool) {
         let editItem = realm.objects(CheckListItem.self)
         try! realm.write {
-            editItem[editCellIndexPath!].itemName = itemName
-            editItem[editCellIndexPath!].isChecked = isChecked
+            editItem[selectedIndexPathRow!].itemName = itemName
+            editItem[selectedIndexPathRow!].isChecked = isChecked
         }
     }
     
@@ -70,7 +70,7 @@ final class ItemListViewController: UIViewController {
         guard unwindSegue.identifier == SegueIdentifier.edit else { return }
         let itemEditVC = unwindSegue.source as! ItemEditViewController
         print(itemEditVC.editedItemName)
-        editRealm(itemName: itemEditVC.editedItemName, isChecked: itemList[editCellIndexPath!].isChecked)
+        editRealm(itemName: itemEditVC.editedItemName, isChecked: itemList[selectedIndexPathRow!].isChecked)
         itemListTableView.reloadData()
     }
     
@@ -103,7 +103,7 @@ extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
     
     //編集前のタスク名をitemEditVCに渡す
     func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
-        editCellIndexPath = indexPath.row //編集するCellのindexPathを取得
+        selectedIndexPathRow = indexPath.row //編集するCellのindexPathを取得
         performSegue(withIdentifier: "itemEdit", sender: itemList[indexPath.row].itemName)
     }
     

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -24,8 +24,6 @@ final class ItemListViewController: UIViewController {
         super.viewDidLoad()
         setUpNib()
         setRealm()
-        
-        print(Realm.Configuration.defaultConfiguration.fileURL!)
     }
     
     private func setUpNib() {
@@ -68,7 +66,6 @@ final class ItemListViewController: UIViewController {
     @IBAction func unwindToVCFromEditVC(_ unwindSegue: UIStoryboardSegue) {
         guard unwindSegue.identifier == SegueIdentifier.edit else { return }
         let itemEditVC = unwindSegue.source as! ItemEditViewController
-        print(itemEditVC.editedItemName)
         editRealm(itemName: itemEditVC.editedItemName, isChecked: itemList[selectedIndexPathRow!].isChecked)
         itemListTableView.reloadData()
     }

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -17,8 +17,8 @@ final class ItemListViewController: UIViewController {
     private var itemList: Results<CheckListItem>!
     private var editCellIndexPath: Int?  //編集するcellのindexPathを保存する変数
     private enum SegueIdentifier {
-            static let edit = "unwindByItemEdit"
-        }
+        static let edit = "unwindByItemEdit"
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -20,6 +20,11 @@ final class ItemListViewController: UIViewController {
         super.viewDidLoad()
         setUpNib()
         setRealm()
+        
+//        print(Realm.Configuration.defaultConfiguration.fileURL!)
+//        let key = Realm.Configuration.defaultConfiguration.encryptionKey!
+//        let hexaDecimal = key.map { String(format: "%.2hhx", $0) }.joined()
+//        print(hexaDecimal)
     }
     
     private func setUpNib() {
@@ -40,8 +45,16 @@ final class ItemListViewController: UIViewController {
         try! realm.write() {
             realm.add(addItem)
         }
-        
     }
+    
+    //　itemNameを更新する関数
+//    private func editRealm(itemName: String, isChecked: Bool) {
+//        let editItem = realm.objects(CheckListItem.self)
+//        try! realm.write {
+//            editItem.itemName = itemName
+//            editItem.isChecked = isChecked
+//        }
+//    }
     
     @IBAction func unwindToVC(_ unwindSegue: UIStoryboardSegue) {
         guard unwindSegue.identifier == IdentifierType.segueId else { return }
@@ -50,6 +63,17 @@ final class ItemListViewController: UIViewController {
         addRealm(itemName: addItemVC.betaCheckItemName, isChecked: false)
         itemListTableView.reloadData()
     }
+    
+    // Segueで渡されたeditedItemName変数を基にeditRealm関数でrealmデータを更新し、TableViewをリロード
+    @IBAction func unwindToVCFromEditVC(_ unwindSegue: UIStoryboardSegue) {
+        guard unwindSegue.identifier == IdentifierType.editSegueId else { return }
+        let itemEditVC = unwindSegue.source as! ItemEditViewController
+        print(itemEditVC.editedItemName)
+//        editRealm(itemName: itemEditVC.editedItemName, isChecked: false)
+        itemListTableView.reloadData()
+        
+    }
+    
 }
 
 extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
@@ -77,7 +101,16 @@ extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
         itemListTableView.reloadRows(at: [indexPath], with: .automatic)
     }
     
+    //編集前のタスク名をitemEditVCに渡す
     func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
-        performSegue(withIdentifier: "itemEdit", sender: nil)
+        performSegue(withIdentifier: "itemEdit", sender: itemList[indexPath.row].itemName)
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "itemEdit" {
+            let nav =  segue.destination as! UINavigationController
+            let itemEditVC = nav.viewControllers[nav.viewControllers.count-1] as! ItemEditViewController
+            itemEditVC.editItemName = sender as! String
+        }
     }
 }

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -16,6 +16,9 @@ final class ItemListViewController: UIViewController {
     @IBOutlet private weak var itemListTableView: UITableView!
     private var itemList: Results<CheckListItem>!
     private var editCellIndexPath: Int?  //編集するcellのindexPathを保存する変数
+    private enum SegueIdentifier {
+            static let edit = "unwindByItemEdit"
+        }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -46,7 +49,7 @@ final class ItemListViewController: UIViewController {
     }
     
     //　itemNameを更新する関数
-    func editRealm(itemName: String, isChecked: Bool) {
+    private func editRealm(itemName: String, isChecked: Bool) {
         let editItem = realm.objects(CheckListItem.self)
         try! realm.write {
             editItem[editCellIndexPath!].itemName = itemName
@@ -64,7 +67,7 @@ final class ItemListViewController: UIViewController {
     
     // Segueで渡されたeditedItemName変数を基にeditRealm関数でrealmデータを更新し、TableViewをリロード
     @IBAction func unwindToVCFromEditVC(_ unwindSegue: UIStoryboardSegue) {
-        guard unwindSegue.identifier == IdentifierType.editSegueId else { return }
+        guard unwindSegue.identifier == SegueIdentifier.edit else { return }
         let itemEditVC = unwindSegue.source as! ItemEditViewController
         print(itemEditVC.editedItemName)
         editRealm(itemName: itemEditVC.editedItemName, isChecked: false)

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -111,7 +111,7 @@ extension ItemListViewController: UITableViewDelegate, UITableViewDataSource {
         if segue.identifier == "itemEdit" {
             let nav =  segue.destination as! UINavigationController
             let itemEditVC = nav.viewControllers[nav.viewControllers.count-1] as! ItemEditViewController
-            itemEditVC.editItemName = sender as! String
+            itemEditVC.selectedItemName = sender as! String
         }
     }
 }

--- a/TodoApp/Views/Controllers/ItemListViewController.swift
+++ b/TodoApp/Views/Controllers/ItemListViewController.swift
@@ -70,7 +70,7 @@ final class ItemListViewController: UIViewController {
         guard unwindSegue.identifier == SegueIdentifier.edit else { return }
         let itemEditVC = unwindSegue.source as! ItemEditViewController
         print(itemEditVC.editedItemName)
-        editRealm(itemName: itemEditVC.editedItemName, isChecked: false)
+        editRealm(itemName: itemEditVC.editedItemName, isChecked: itemList[editCellIndexPath!].isChecked)
         itemListTableView.reloadData()
     }
     

--- a/TodoApp/Views/ItemEdit.storyboard
+++ b/TodoApp/Views/ItemEdit.storyboard
@@ -26,6 +26,9 @@
                                 <rect key="frame" x="101" y="148" width="293" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
+                                <connections>
+                                    <action selector="checkTextFieldIsEmpty:" destination="kcR-wB-Iad" eventType="editingChanged" id="h29-eg-QWc"/>
+                                </connections>
                             </textField>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="OVp-Vx-BWL"/>
@@ -45,10 +48,20 @@
                                 <action selector="cancelButton:" destination="kcR-wB-Iad" id="CII-TP-hzW"/>
                             </connections>
                         </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" title="Save" id="Wma-qt-ArF"/>
+                        <barButtonItem key="rightBarButtonItem" title="Save" id="Wma-qt-ArF">
+                            <connections>
+                                <action selector="saveButton:" destination="kcR-wB-Iad" id="JLP-MH-xEu"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="editTextField" destination="pL7-fM-fga" id="Df2-Am-dVy"/>
+                        <outlet property="saveButton" destination="Wma-qt-ArF" id="KTL-Ha-MAE"/>
+                        <segue destination="nzw-Xs-iSb" kind="unwind" identifier="unwindByItemEdit" unwindAction="unwindToVCFromEditVC:" id="0Cl-29-axN"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x6n-7p-9wI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="nzw-Xs-iSb" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="945" y="-15"/>
         </scene>


### PR DESCRIPTION
## 今回行った作業の詳細を記入

<!--具体的にどんな作業を行ったのか記入してください -->
・昨日のドラフトプルリクの際、ItemEditVC内のTextFieldに文字が入力されていなければアラートを出すという実装をしましたが、文字が入力されていない場合はSaveボタンを押せなくするのが課題であったので、その点を修正しました。

・editRealm()を定義（Realmデータの更新を行うメソッド）
・ItemListVCとItemEditVC間のunwindSegueを定義（その際、ItemEditVCから渡されたeditedItemNameを引数にeditRealm()が呼び出され、Realmデータが更新される）
・reloadDataで編集したitemNameを表示

## レビューして欲しい内容

<!-- 特にレビューして欲しいところがあれば記入してください -->


## 勉強になったところ

<!-- 今回の作業で勉強になったことを記入してください -->
テキストフィールドに一文字も入力されていない際にSaveボタンを押せなくするメソッドを定義する際に、テキストフィールドが編集されるたびに呼ばれるメソッドが用意されているということが勉強になりました。（下に参考サイトのURLを貼っておきます）

## 躓いたところ

<!-- 今回の作業でわからなかったこと、躓いたところがあれば記入してください -->
・しっかり動くか確認してほしいです。

## 参考になった資料などあれば共有してください

<!-- 今回の作業で調べて参考にした資料や記事等あればURLを貼ってみんなに共有しましょう!! -->
https://satoriku.com/btn-inactive/

## スクリーンショット(Before, After)

<!-- もし画像などあれば貼ってみてください-->

Before | After
------------- | -------------
<img src="" width="320"> | <img src="" width="320">

## その他
<!-- 上記以外でも共有したいことがあればこちらに記入してください -->

